### PR TITLE
Add service provider

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -16,6 +16,7 @@ type ServiceProvider @entity {
   rewardsFeePercentage: BigInt!
   totalDelegatedStake: BigInt!
   rewardsProgrammeId: BigInt!
+  serviceProvider: Bytes!
   serviceProviderManager: Bytes!
   serviceProviderBond: BigInt!
   withdrawalRequestAmount: BigInt!

--- a/src/service-provider-mapping.ts
+++ b/src/service-provider-mapping.ts
@@ -14,12 +14,9 @@ import {
     ExitedServiceProviderBond, ExitDelegatedStake
 } from "../generated/templates/ServiceProvider/ServiceProvider"
 
-import { dataSource } from '@graphprotocol/graph-ts'
-
 import {ZERO, ZERO_ADDRESS} from "./helpers"
 import {Address} from "@graphprotocol/graph-ts/index";
 import {BigInt} from "@graphprotocol/graph-ts";
-import { safeLoadStakingRewards } from "./staking-rewards-mapping";
 
 // loads a delegator for a specific service provider
 function safeLoadDelegator(delegator: Address, serviceProvider: Address): Delegation {
@@ -60,10 +57,6 @@ export function safeLoadServiceProvider(id: string): ServiceProvider {
 }
 
 export function handleServiceProviderStakedBond(event: StakedServiceProviderBond): void {
-    // dataSource.address is the address for the StakingRewards contract in the subgraph.yaml config (line 9)
-    const stakingRewards = safeLoadStakingRewards(dataSource.address.toString())
-    stakingRewards.save()
-
     const serviceProviderContract = ServiceProviderContract.bind(event.address)
 
     let serviceProvider = safeLoadServiceProvider(event.address.toHexString())
@@ -72,7 +65,7 @@ export function handleServiceProviderStakedBond(event: StakedServiceProviderBond
     serviceProvider.serviceProviderManager = event.params.serviceProviderManager
     serviceProvider.rewardsFeePercentage = serviceProviderContract.rewardsFeePercentage()
     serviceProvider.totalDelegatedStake = serviceProviderContract.delegatedStake(event.params.serviceProvider)
-    serviceProvider.serviceProviderBond = stakingRewards.minRequiredStakingAmountForServiceProviders
+    serviceProvider.serviceProviderBond = BigInt.fromI32(2_000_000).times((BigInt.fromI32(10).pow(18))) // 2_000_000 * 10 ** 18
     serviceProvider.save()
 }
 

--- a/src/staking-rewards-mapping.ts
+++ b/src/staking-rewards-mapping.ts
@@ -5,11 +5,11 @@ import {
     MinServiceProviderFeeUpdated,
     ServiceProviderWhitelisted
 } from "../generated/StakingRewards/StakingRewards";
-import {safeLoadServiceProvider} from "./service-provider-mapping";
-import {BigInt, Bytes} from "@graphprotocol/graph-ts";
-import {StakingReward} from "../generated/schema";
+import { safeLoadServiceProvider } from "./service-provider-mapping";
+import { BigInt } from "@graphprotocol/graph-ts";
+import { StakingReward } from "../generated/schema";
 
-function safeLoadStakingRewards(id: string): StakingReward {
+export function safeLoadStakingRewards(id: string): StakingReward {
     let entity = StakingReward.load(id)
 
     if (entity == null) {
@@ -29,7 +29,7 @@ export function handleNewServiceProviderWhitelisted(event: ServiceProviderWhitel
     const stakingRewards = safeLoadStakingRewards(event.address.toHexString());
     stakingRewards.save()
     const serviceProvider = safeLoadServiceProvider(event.params.serviceProviderContract.toHexString());
-    serviceProvider.serviceProviderManager = event.params.serviceProvider
+    serviceProvider.serviceProvider = event.params.serviceProvider
     serviceProvider.serviceProviderBond = stakingRewards.minRequiredStakingAmountForServiceProviders
     serviceProvider.save()
     ServiceProvider.create(event.params.serviceProviderContract)

--- a/src/staking-rewards-mapping.ts
+++ b/src/staking-rewards-mapping.ts
@@ -30,7 +30,6 @@ export function handleNewServiceProviderWhitelisted(event: ServiceProviderWhitel
     stakingRewards.save()
     const serviceProvider = safeLoadServiceProvider(event.params.serviceProviderContract.toHexString());
     serviceProvider.serviceProvider = event.params.serviceProvider
-    serviceProvider.serviceProviderBond = stakingRewards.minRequiredStakingAmountForServiceProviders
     serviceProvider.save()
     ServiceProvider.create(event.params.serviceProviderContract)
 }


### PR DESCRIPTION
We have have noticed that the serviceProviderManager is actually the serviceProvider address. We need both so I have added the serviceProviderManager field to the ServiceProvider entity.

There was also an issue with validators showing 2million stake when they had not been fully set up yet. The subgraph will now set the 2 million initial stake in the "StakedServiceProviderBond" event instead of the "ServiceProviderWhitelisted" event.